### PR TITLE
Add conditional for OSX Editor scenario

### DIFF
--- a/LSL.cs
+++ b/LSL.cs
@@ -899,29 +899,29 @@ public class liblsl
     class dll
     {
 
-#if (UNITY_EDITOR_WIN && UNITY_EDITOR_64) || UNITY_EDITOR_LINUX
+		#if (UNITY_EDITOR_WIN && UNITY_EDITOR_64) || UNITY_EDITOR_LINUX || (UNITY_EDITOR_OSX && UNITY_EDITOR_64)
             const string pathToAllLibs = "Assets/LSL4Unity/lib/";
-#elif UNITY_STANDALONE_WIN || UNITY_STANDALONE_LINUX || UNITY_STANDALONE_OSX
+		#elif UNITY_STANDALONE_WIN || UNITY_STANDALONE_LINUX || UNITY_STANDALONE_OSX
             const string pathToAllLibs = "../Plugins/";
-#endif
+		#endif
 
-#if (UNITY_EDITOR_WIN && UNITY_EDITOR_64) || UNITY_STANDALONE_WIN
+		#if (UNITY_EDITOR_WIN && UNITY_EDITOR_64) || UNITY_STANDALONE_WIN
             const string libname = "liblsl64.dll";
-#elif UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+		#elif UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
             const string libname =  "liblsl32.dll";
-#endif
+		#endif
 
-#if (UNITY_EDITOR_LINUX && UNITY_EDITOR_64) || UNITY_STANDALONE_LINUX
+		#if (UNITY_EDITOR_LINUX && UNITY_EDITOR_64) || UNITY_STANDALONE_LINUX
            const string libname = "liblsl64.so";
-#elif UNITY_EDITOR_LINUX && UNITY_STANDALONE_LINUX
+		#elif UNITY_EDITOR_LINUX && UNITY_STANDALONE_LINUX
            const string libname =  "liblsl32.so";
-#endif
+		#endif
 
-#if (Unity_EDITOR_OSX && UNITY_EDITOR_64) || UNITY_STANDALONE_OSX
+		#if (Unity_EDITOR_OSX && UNITY_EDITOR_64) || UNITY_STANDALONE_OSX
            const string libname = "liblsl64.bundle";
-#elif Unity_EDITOR_OSX && UNITY_STANDALONE_OSX
+		#elif Unity_EDITOR_OSX && UNITY_STANDALONE_OSX
            const string libname =  "liblsl32.bundle";
-#endif
+		#endif
 
         const string pathToLib = pathToAllLibs + libname;
 


### PR DESCRIPTION
With this small change I seem able to send markers from Unity as tested according to your tutorial & received using the liblsl-python ReceiveStringMarkers.py

One thing to consider explicitly noting in the tutorial is that the default type of a marker stream in LSL's apps/example scripts and in BCILAB's LSL-stream-follower seems to be "Markers", rather than the "LSL_Marker_Strings" default in your LSLMarkerStream.cs script. 

This proves [Issue 1](https://github.com/xfleckx/LSL4Unity/issues/1) is resolved, and [Issue 2](https://github.com/xfleckx/LSL4Unity/issues/2) is at minimum resolved for 64bit OSX editor mode.