### PR TITLE
Fix Resolver for streams with same name

### DIFF
--- a/Scripts/Resolver.cs
+++ b/Scripts/Resolver.cs
@@ -79,7 +79,7 @@ namespace Assets.LSL4Unity.Scripts
                 // add new found streams to the cache
                 foreach (var item in results)
                 {
-                    if (!knownStreams.Any(s => s.Name == item.name()))
+                    if (!knownStreams.Any(s => s.Name == item.name() && s.Type == item.type()))
                     {
 
                         Debug.Log(string.Format("Found new Stream {0}", item.name()));


### PR DESCRIPTION
Resolver can now add streams with same name but different type. Some applications, such as NIC for EEG, use several streams with the same name but different types: http://wiki.neuroelectrics.com/index.php/Interacting_with_NIC#Receiving_and_sending_data_streams_using_LSL
Before this change, Resolver only added one of these streams (e.g.  'name: NIC, type EEG' OR 'name: NIC, type Accelerometer'). Now, it adds all of them (e.g.  'name: NIC, type EEG' AND 'name: NIC, type Accelerometer').