### PR TITLE
Creates a compile time constant to allow for compile time checking of…

### DIFF
--- a/LSL.cs
+++ b/LSL.cs
@@ -2,6 +2,8 @@
 using System.Runtime.InteropServices;
 using System.Collections;
 
+#define LSL4UnityLibrary
+
 /**
 * C# API for the lab streaming layer.
 * 


### PR DESCRIPTION
Creates a compile time constant to allow for compile time checking of the existence of the LSL library to prevent compile-time errors if the project is not added.