### PR TITLE
Fix BaseInlet setup when receiving irregular rate stream

### DIFF
--- a/Runtime/Scripts/BaseInlet.cs
+++ b/Runtime/Scripts/BaseInlet.cs
@@ -69,7 +69,12 @@ namespace LSL4Unity.Utils
             Debug.Log(string.Format("LSL Stream {0} found for {1}", stream_info.name(), name));
 
             inlet = new StreamInlet(stream_info);
-            int buf_samples = (int)Mathf.Ceil((float)(inlet.info().nominal_srate() * maxChunkDuration));
+            double samplingRate = inlet.info().nominal_srate();
+            if (samplingRate == LSL.LSL.IRREGULAR_RATE) {
+                // Irregular rates are usually used for markers. This sampling rate will allow init of buffers that should largely cover normal use cases.
+                samplingRate = 128;
+            }
+            int buf_samples = (int)Mathf.Ceil((float)(samplingRate * maxChunkDuration));
             int nChannels = inlet.info().channel_count();
 
             timestamp_buffer = new double[buf_samples];


### PR DESCRIPTION
Looking at the BaseInlet class, the structures to receive data from a stream are initialized based on the sampling rate and channel count.
When receiving a stream with irregular rate ( nominalSamplingRate = 0), the data buffer array is therefore of size 0.
This prevents from reading any data from the stream.

Irregular rate is usually used for Markers streams. I am not sure of any other usages ?
Those markers don't normally have a very high sampling rate.
The fix I propose is therefore to initialize the structures with a size of 128 (as in 128 events per seconds), which should be more than enough to read such type of data.

A more flexible way to do this would be to read sample by sample until done in the pullChunk method but I thought this might not be as efficient and the fix as it is should be sufficient. What do you think about it ?